### PR TITLE
docs: place device_credentials_installer earlier

### DIFF
--- a/python/modem-firmware-1.3+/README.md
+++ b/python/modem-firmware-1.3+/README.md
@@ -10,192 +10,6 @@ Use Python pip to install missing packages such as `cbor2`, `pyserial`, `coloram
 ~$ pip3 install cbor2 pyserial colorama pyOpenSSL
 ```
 
-## Modem Credentials Parser
-This script parses the output of `AT%KEYGEN` and `AT%ATTESTTOKEN`.   Each command outputs two base64 strings joined by a `.` character.  The first string is the command specific data.  The second string is the [COSE](https://datatracker.ietf.org/doc/html/rfc8152) signature of the first string.
-The parsed data is displayed in the output.  Providing the COSE string to this script is optional, as it is only used to display extra information.  When providing `AT%KEYGEN` output, PEM files can be optionally saved.
-
-
-```
-usage: modem_credentials_parser.py [-h] [-k KEYGEN] [-a ATTEST]
-
-Modem Credentials Parser
-
-optional arguments:
-  -h, --help                  show this help message and exit
-  -k KEYGEN, --keygen KEYGEN
-                              base64url string: KEYGEN output
-  -a ATTEST, --attest ATTEST
-                              base64url string: ATTESTTOKEN output
-  -s, --save                  Save PEM file(s): <UUID>_<sec_tag>_<type>.pem
-  -p PATH, --path PATH        Path to save PEM file. Selects -s
-  -f FILEPREFIX, --fileprefix FILEPREFIX
-                              Prefix for output files (<prefix><UUID>_<sec_tag>_<type>.pem). Selects -s
-```
-
-Parse modem [KEYGEN](https://infocenter.nordicsemi.com/topic/ref_at_commands/REF/at_commands/security/keygen_set.html) output; with or without COSE string:
-
-`python3 modem_credentials_parser.py -k <base64url AT%KEYGEN output>`
-
-Parse modem keygen output and save PEM file(s); COSE string is required:
-
-`python3 modem_credentials_parser.py -k <base64url AT%KEYGEN output> -s`
-
-`python3 modem_credentials_parser.py -k <base64url AT%KEYGEN output> -p <my_output_path> -f <my_file_prefix>`
-
-Parse modem [ATTESTTOKEN](https://infocenter.nordicsemi.com/topic/ref_at_commands/REF/at_commands/security/attesttoken_set.html) output; with or without COSE string:
-
-`python3 modem_credentials_parser.py -a <base64url AT%ATTESTTOKEN output>`
-
-## Examples
-
-### KEYGEN - Certificate Signing Request (CSR): `AT%KEYGEN=17,2,0`
-```
-python3 modem_credentials_parser.py -k MIIBCjCBrwIBADAvMS0wKwYDVQQDDCQ1MDM2MzE1NC0zOTMxLTQ0ZjAtODAyMi0xMjFiNjQwMTYyN2QwWTATBgcqhkjOPQIBBggqhkjOPQMBBwNCAAQqD6pNfa29o_EXnw62bnQWr8-JqsNh_HZxS3k3bMD4KZ8-qxnvgeoiqQ5zAycEP_Wcmzqypvwyf3qWMrZ2VB5aoB4wHAYJKoZIhvcNAQkOMQ8wDTALBgNVHQ8EBAMCA-gwDAYIKoZIzj0EAwIFAANIADBFAiEAv7OLZ_dXbszfhhjcLMUT72wTmw-z6GlgWxVhyWgR27ACIAvY_lPu3yfYZY5AL6uYTkUFp4GQkbSOUC_lsHyCxOuG.0oRDoQEmoQRBIVhL2dn3hQlQUDYxVDkxRPCAIhIbZAFifUERWCBwKj1W8FsvclMdZQgl4gBB4unZMYw0toU6uQZuXHLoDFAbhyLuHetYFWbiyxNZsnzSWEDUiTl7wwFt0hEsCiEQsxj-hCtpBk8Za8UXfdAycpx2faCOPJIrkfmiSS8-Y6_2tTAoAMN1BiWiTOimY1wZE3Ud
-
-Parsing AT%KEYGEN output:
-
------BEGIN CERTIFICATE REQUEST-----
-MIIBCjCBrwIBADAvMS0wKwYDVQQDDCQ1MDM2MzE1NC0zOTMxLTQ0ZjAtODAyMi0x
-MjFiNjQwMTYyN2QwWTATBgcqhkjOPQIBBggqhkjOPQMBBwNCAAQqD6pNfa29o/EX
-nw62bnQWr8+JqsNh/HZxS3k3bMD4KZ8+qxnvgeoiqQ5zAycEP/Wcmzqypvwyf3qW
-MrZ2VB5aoB4wHAYJKoZIhvcNAQkOMQ8wDTALBgNVHQ8EBAMCA+gwDAYIKoZIzj0E
-AwIFAANIADBFAiEAv7OLZ/dXbszfhhjcLMUT72wTmw+z6GlgWxVhyWgR27ACIAvY
-/lPu3yfYZY5AL6uYTkUFp4GQkbSOUC/lsHyCxOuG
------END CERTIFICATE REQUEST-----
-
-Device public key:
------BEGIN PUBLIC KEY-----
-MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEKg+qTX2tvaPxF58Otm50Fq/PiarD
-Yfx2cUt5N2zA+CmfPqsZ74HqIqkOcwMnBD/1nJs6sqb8Mn96ljK2dlQeWg==
------END PUBLIC KEY-----
-
-SHA256 Digest:
-702a3d56f05b2f72531d650825e20041e2e9d9318c34b6853ab9066e5c72e80c
-
-* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
-COSE:
-  Prot Hdr:   1 : -7 (ECDSA w/ SHA-256)
-  Unprot Hdr: 4 : -2 (identity_key)
-  ---------------
-  Attestation:
-    Payload ID: CSR_msg_v1
-    Dev UUID:  50363154-3931-44f0-8022-121b6401627d
-    sec_tag:    17
-    SHA256:     702a3d56f05b2f72531d650825e20041e2e9d9318c34b6853ab9066e5c72e80c
-    Nonce:      1b8722ee1deb581566e2cb1359b27cd2
-  ---------------
-  Sig:
-      d489397bc3016dd2112c0a2110b318fe842b69064f196bc5177dd032729c767da08e3c922b91f9a2492f3e63aff6b5302800c3750625a24ce8a6635c1913751d
-
-COSE digest matches payload
-* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
-```
-
-### KEYGEN - Public Key: `AT%KEYGEN=16,2,1`
-```
-python3 modem_credentials_parser.py -k MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEZKgDx0O0FKa7i1yFoxYngNdV5Csyi4rEPHcFTfeBVtkkJX-G0QZs-yesfzIaPs91b4x5xYN_g28k63gkeVMJwA.0oRDoQEmoQRBIVhL2dn3hQhQUDYxVDkxRPCAIhIbZAFifUEQWCDlovwqMVoJ1W-x93Tqypy2v_1ALv3-GCF1R9gYIy2WVlBQXvxKqA9JTveFh3nVwce-WEAMltwSSkVh8jSBPhP79ndSG0HJTOaTF9SExIq-FstjdLUW2inxdvVfqzLa05rgXqxshN5vfQIs22QT-swCt30h
-
-Parsing AT%KEYGEN output:
-
-Device public key:
------BEGIN PUBLIC KEY-----
-MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEZKgDx0O0FKa7i1yFoxYngNdV5Csy
-i4rEPHcFTfeBVtkkJX+G0QZs+yesfzIaPs91b4x5xYN/g28k63gkeVMJwA==
------END PUBLIC KEY-----
-
-SHA256 Digest:
-e5a2fc2a315a09d56fb1f774eaca9cb6bffd402efdfe18217547d818232d9656
-
-* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
-COSE:
-  Prot Hdr:   1 : -7 (ECDSA w/ SHA-256)
-  Unprot Hdr: 4 : -2 (identity_key)
-  ---------------
-  Attestation:
-    Payload ID: pubkey_msg_v2
-    Dev UUID:   50363154-3931-44f0-8022-121b6401627d
-    sec_tag:    16
-    SHA256:     e5a2fc2a315a09d56fb1f774eaca9cb6bffd402efdfe18217547d818232d9656
-    Nonce:      505efc4aa80f494ef7858779d5c1c7be
-  ---------------
-  Sig:
-      0c96dc124a4561f234813e13fbf677521b41c94ce69317d484c48abe16cb6374b516da29f176f55fab32dad39ae05eac6c84de6f7d022cdb6413facc02b77d21
-
-COSE digest matches payload
-* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
-```
-
-### AT%ATTESTTOKEN
-```
-python3 modem_credentials_parser.py -a 2dn3hQFQUDYxVDkxRPCAIhIbZAFifQNQGv86y_GmR2SiY0wmRsHGVFDT791_BPH8YOWFiyCHND1q.0oRDoQEmoQRBIfZYQGuXwJliinHc6xDPruiyjsaXyXZbZVpUuOhHG9YS8L05VuglCcJhMN4EUhWVGpaHgNnHHno6ahi-d5tOeZmAcNY
-
-Parsing AT%ATTESTTOKEN output:
-
----------------
-Msg Type:    Device identity message v1
-Dev UUID:    50363154-3931-44f0-8022-121b6401627d
-Dev Type:    NRF9160 SIAA
-FW UUID:     1aff3acb-f1a6-4764-a263-4c2646c1c654
----------------
-* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
-COSE:
-  Prot Hdr:   1 : -7 (ECDSA w/ SHA-256)
-  Unprot Hdr: 4 : -2 (identity_key)
-  ---------------
-  Attestation:
-    Not present
-  ---------------
-  Sig:
-      6b97c099628a71dceb10cfaee8b28ec697c9765b655a54b8e8471bd612f0bd3956e82509c26130de045215951a968780d9c71e7a3a6a18be779b4e79998070d6
-* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
-```
-
-### KEYGEN - Certificate Signing Request (CSR) + File Save: `AT%KEYGEN=17,2,0`
-```
-python3 modem_credentials_parser.py -k MIIBCjCBrwIBADAvMS0wKwYDVQQDDCQ1MDM2MzE1NC0zOTMxLTQ0ZjAtODAyMi0xMjFiNjQwMTYyN2QwWTATBgcqhkjOPQIBBggqhkjOPQMBBwNCAAQqD6pNfa29o_EXnw62bnQWr8-JqsNh_HZxS3k3bMD4KZ8-qxnvgeoiqQ5zAycEP_Wcmzqypvwyf3qWMrZ2VB5aoB4wHAYJKoZIhvcNAQkOMQ8wDTALBgNVHQ8EBAMCA-gwDAYIKoZIzj0EAwIFAANIADBFAiEAv7OLZ_dXbszfhhjcLMUT72wTmw-z6GlgWxVhyWgR27ACIAvY_lPu3yfYZY5AL6uYTkUFp4GQkbSOUC_lsHyCxOuG.0oRDoQEmoQRBIVhL2dn3hQlQUDYxVDkxRPCAIhIbZAFifUERWCBwKj1W8FsvclMdZQgl4gBB4unZMYw0toU6uQZuXHLoDFAbhyLuHetYFWbiyxNZsnzSWEDUiTl7wwFt0hEsCiEQsxj-hCtpBk8Za8UXfdAycpx2faCOPJIrkfmiSS8-Y6_2tTAoAMN1BiWiTOimY1wZE3Ud -p /my_devices/pem_files -f hw_rev2-
-
-Parsing AT%KEYGEN output:
-
------BEGIN CERTIFICATE REQUEST-----
-MIIBCjCBrwIBADAvMS0wKwYDVQQDDCQ1MDM2MzE1NC0zOTMxLTQ0ZjAtODAyMi0x
-MjFiNjQwMTYyN2QwWTATBgcqhkjOPQIBBggqhkjOPQMBBwNCAAQqD6pNfa29o/EX
-nw62bnQWr8+JqsNh/HZxS3k3bMD4KZ8+qxnvgeoiqQ5zAycEP/Wcmzqypvwyf3qW
-MrZ2VB5aoB4wHAYJKoZIhvcNAQkOMQ8wDTALBgNVHQ8EBAMCA+gwDAYIKoZIzj0E
-AwIFAANIADBFAiEAv7OLZ/dXbszfhhjcLMUT72wTmw+z6GlgWxVhyWgR27ACIAvY
-/lPu3yfYZY5AL6uYTkUFp4GQkbSOUC/lsHyCxOuG
------END CERTIFICATE REQUEST-----
-
-Device public key:
------BEGIN PUBLIC KEY-----
-MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEKg+qTX2tvaPxF58Otm50Fq/PiarD
-Yfx2cUt5N2zA+CmfPqsZ74HqIqkOcwMnBD/1nJs6sqb8Mn96ljK2dlQeWg==
------END PUBLIC KEY-----
-
-SHA256 Digest:
-702a3d56f05b2f72531d650825e20041e2e9d9318c34b6853ab9066e5c72e80c
-
-* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
-COSE:
-  Prot Hdr:   1 : -7 (ECDSA w/ SHA-256)
-  Unprot Hdr: 4 : -2 (identity_key)
-  ---------------
-  Attestation:
-    Payload ID: CSR_msg_v1
-    Dev UUID:   50363154-3931-44f0-8022-121b6401627d
-    sec_tag:    17
-    SHA256:     702a3d56f05b2f72531d650825e20041e2e9d9318c34b6853ab9066e5c72e80c
-    Nonce:      1b8722ee1deb581566e2cb1359b27cd2
-  ---------------
-  Sig:
-      d489397bc3016dd2112c0a2110b318fe842b69064f196bc5177dd032729c767da08e3c922b91f9a2492f3e63aff6b5302800c3750625a24ce8a6635c1913751d
-
-COSE digest matches payload
-* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
-Argument -s has been selected since path/fileprefix was specified
-File created: /my_devices/pem_files/hw_rev2-50363154-3931-44f0-8022-121b6401627d_17_csr.pem
-File created: /my_devices/pem_files/hw_rev2-50363154-3931-44f0-8022-121b6401627d_17_pub.pem
-```
-
 ## Create CA Cert
 This script creates a self-signed CA certificate and an associated EC keypair.   The CA cert and private key can then be used to create device credentials.  Generally, this script needs to be called only once and then its output can be used to produce many device credentials.
 
@@ -233,69 +47,18 @@ File created: /my_ca/my_company-0x3bc7f3b014a8ad492999c594f08bbc2fcffc5fd1_prv.p
 File created: /my_ca/my_company-0x3bc7f3b014a8ad492999c594f08bbc2fcffc5fd1_pub.pem
 ```
 
-## Create Device Credentials
-This script creates device credentials for use with nRF Cloud.  It requires a CA certificate and the associated private key as an input.  It optionally accepts a CSR (from `AT%KEYGEN`/modem_credentials_parser.py).
-
-The output file name format is as follows:
-`<your_prefix><CN>_crt.pem`
-`<your_prefix><CN>_pub.pem`
-if no CSR provided:
-`<your_prefix><CN>_prv.pem`
-If no CN (common name) is provided/available, the serial number hex value will be used.
-```
-usage: create_device_credentials.py [-h] -ca CA -ca_key CA_KEY -c C [-st ST] [-l L] [-o O] [-ou OU] [-cn CN] [-e EMAIL] [-dv DV]
-            [-p PATH] [-f FILEPREFIX] [-csr CSR]
-
-Create Device Credentials
-
-optional arguments:
-  -h, --help            show this help message and exit
-  -ca CA                Filepath to your CA cert PEM
-  -ca_key CA_KEY        Filepath to your CA's private key PEM
-  -c C                  2 character country code; required if CSR is not provided
-  -st ST                State or Province; ignored if CSR is provided
-  -l L                  Locality; ignored if CSR is provided
-  -o O                  Organization; ignored if CSR is provided
-  -ou OU                Organizational Unit; ignored if CSR is provided
-  -cn CN                Common Name; use nRF Cloud device ID/MQTT client ID; ignored if CSR is provided
-  -e EMAIL, --email EMAIL
-                        E-mail address; ignored if CSR is provided
-  -dv DV                Number of days cert is valid
-  -p PATH, --path PATH  Path to save PEM files.
-  -f FILEPREFIX, --fileprefix FILEPREFIX
-                        Prefix for output files
-  -csr CSR              Filepath to CSR PEM from device
-```
-
-## Examples
-
-### No CSR provided:
-```
-python3 create_device_credentials.py -ca /my_ca/my_company-0x3bc7f3b014a8ad492999c594f08bbc2fcffc5fd1_ca.pem -ca_key /my_ca/my_company-0x3bc7f3b014a8ad492999c594f08bbc2fcffc5fd1_prv.pem -c US -st WA -l Seattle -o "My Company" -ou "Devs" -cn my-unique-device-id -e email@example.com -dv 2000 -p /dev_credentials -f hw_rev2-
-Creating device credentials...
-File created: /dev_credentials/hw_rev2-my-unique-device-id_crt.pem
-File created: /dev_credentials/hw_rev2-my-unique-device-id_pub.pem
-File created: /dev_credentials/hw_rev2-my-unique-device-id_prv.pem
-```
-
-### CSR provided:
-```
-python3 create_device_credentials.py -ca /my_ca/my_company-0x3bc7f3b014a8ad492999c594f08bbc2fcffc5fd1_ca.pem -ca_key /my_ca/my_company-0x3bc7f3b014a8ad492999c594f08bbc2fcffc5fd1_prv.pem -csr /my_devices/pem_files/hw_rev2-50363154-3931-44f0-8022-121b6401627d_17_csr.pem -dv 2000 -p /dev_credentials -f hw_rev2-
-Creating device credentials...
-File created: /dev_credentials/hw_rev2-50363154-3931-44f0-8022-121b6401627d_crt.pem
-File created: /dev_credentials/hw_rev2-50363154-3931-44f0-8022-121b6401627d_pub.pem
-```
-
 ## Device Credentials Installer
 
-This script automates the process of generating and programming device credentials to
-a device such as a Thingy:91 or 9160DK running an nRF Connect SDK application
-containing the AT host library. It can also install on an LTE gateway, by
-interacting with the built-in shell.
+This script automates the process of generating and programming device credentials to a device such as a Thingy:91 or 9160DK running an nRF Connect SDK application containing the AT host library.
+It can also install on an LTE gateway, by interacting with the built-in shell.
 
-Note: if only a single supported device is detected on a serial port, it will be
-automatically selected and used. Otherwise, the script displays a list of detected
-devices and gives the user a choice of which to use.
+It requires you to use the `create_ca_cert.py` above once ahead of time to generate the required CA and CA key.
+
+It utilizes methods within the classes inside the other scripts `modem_credentials_parser.py` and `create_device_credentials.py`.
+You do not need to use them directly unless `device_credentials_installer.py` does not meet your needs.
+
+Note: if only a single supported device is detected on a serial port, it will be automatically selected and used.
+Otherwise, the script displays a list of detected devices and gives the user a choice of which to use.
 
 ```
 usage: device_credentials_installer.py [-h] [--dv DV] [--ca CA] [--ca_key CA_KEY] [--csv CSV] [--port PORT] [-a] [-A]
@@ -552,4 +315,247 @@ saving provisioning endpoint csv file provision.csv...
 file saved
 
 C:\utils>
+```
+
+## Modem Credentials Parser
+The script above, `device_credentials_installer.py` makes use of this script, `modem_credentials_parser.py`, so if you use the former, you do not need to also follow the directions below.  If `device_credentials_installer.py` does not meet your needs, you can use `modem_credentials_parser.py` directly to take advantage of additional options.
+
+This script parses the output of `AT%KEYGEN` and `AT%ATTESTTOKEN`.   Each command outputs two base64 strings joined by a `.` character.  The first string is the command specific data.  The second string is the [COSE](https://datatracker.ietf.org/doc/html/rfc8152) signature of the first string.
+The parsed data is displayed in the output.  Providing the COSE string to this script is optional, as it is only used to display extra information.  When providing `AT%KEYGEN` output, PEM files can be optionally saved.
+
+
+```
+usage: modem_credentials_parser.py [-h] [-k KEYGEN] [-a ATTEST]
+
+Modem Credentials Parser
+
+optional arguments:
+  -h, --help                  show this help message and exit
+  -k KEYGEN, --keygen KEYGEN
+                              base64url string: KEYGEN output
+  -a ATTEST, --attest ATTEST
+                              base64url string: ATTESTTOKEN output
+  -s, --save                  Save PEM file(s): <UUID>_<sec_tag>_<type>.pem
+  -p PATH, --path PATH        Path to save PEM file. Selects -s
+  -f FILEPREFIX, --fileprefix FILEPREFIX
+                              Prefix for output files (<prefix><UUID>_<sec_tag>_<type>.pem). Selects -s
+```
+
+Parse modem [KEYGEN](https://infocenter.nordicsemi.com/topic/ref_at_commands/REF/at_commands/security/keygen_set.html) output; with or without COSE string:
+
+`python3 modem_credentials_parser.py -k <base64url AT%KEYGEN output>`
+
+Parse modem keygen output and save PEM file(s); COSE string is required:
+
+`python3 modem_credentials_parser.py -k <base64url AT%KEYGEN output> -s`
+
+`python3 modem_credentials_parser.py -k <base64url AT%KEYGEN output> -p <my_output_path> -f <my_file_prefix>`
+
+Parse modem [ATTESTTOKEN](https://infocenter.nordicsemi.com/topic/ref_at_commands/REF/at_commands/security/attesttoken_set.html) output; with or without COSE string:
+
+`python3 modem_credentials_parser.py -a <base64url AT%ATTESTTOKEN output>`
+
+## Examples
+
+### KEYGEN - Certificate Signing Request (CSR): `AT%KEYGEN=17,2,0`
+```
+python3 modem_credentials_parser.py -k MIIBCjCBrwIBADAvMS0wKwYDVQQDDCQ1MDM2MzE1NC0zOTMxLTQ0ZjAtODAyMi0xMjFiNjQwMTYyN2QwWTATBgcqhkjOPQIBBggqhkjOPQMBBwNCAAQqD6pNfa29o_EXnw62bnQWr8-JqsNh_HZxS3k3bMD4KZ8-qxnvgeoiqQ5zAycEP_Wcmzqypvwyf3qWMrZ2VB5aoB4wHAYJKoZIhvcNAQkOMQ8wDTALBgNVHQ8EBAMCA-gwDAYIKoZIzj0EAwIFAANIADBFAiEAv7OLZ_dXbszfhhjcLMUT72wTmw-z6GlgWxVhyWgR27ACIAvY_lPu3yfYZY5AL6uYTkUFp4GQkbSOUC_lsHyCxOuG.0oRDoQEmoQRBIVhL2dn3hQlQUDYxVDkxRPCAIhIbZAFifUERWCBwKj1W8FsvclMdZQgl4gBB4unZMYw0toU6uQZuXHLoDFAbhyLuHetYFWbiyxNZsnzSWEDUiTl7wwFt0hEsCiEQsxj-hCtpBk8Za8UXfdAycpx2faCOPJIrkfmiSS8-Y6_2tTAoAMN1BiWiTOimY1wZE3Ud
+
+Parsing AT%KEYGEN output:
+
+-----BEGIN CERTIFICATE REQUEST-----
+MIIBCjCBrwIBADAvMS0wKwYDVQQDDCQ1MDM2MzE1NC0zOTMxLTQ0ZjAtODAyMi0x
+MjFiNjQwMTYyN2QwWTATBgcqhkjOPQIBBggqhkjOPQMBBwNCAAQqD6pNfa29o/EX
+nw62bnQWr8+JqsNh/HZxS3k3bMD4KZ8+qxnvgeoiqQ5zAycEP/Wcmzqypvwyf3qW
+MrZ2VB5aoB4wHAYJKoZIhvcNAQkOMQ8wDTALBgNVHQ8EBAMCA+gwDAYIKoZIzj0E
+AwIFAANIADBFAiEAv7OLZ/dXbszfhhjcLMUT72wTmw+z6GlgWxVhyWgR27ACIAvY
+/lPu3yfYZY5AL6uYTkUFp4GQkbSOUC/lsHyCxOuG
+-----END CERTIFICATE REQUEST-----
+
+Device public key:
+-----BEGIN PUBLIC KEY-----
+MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEKg+qTX2tvaPxF58Otm50Fq/PiarD
+Yfx2cUt5N2zA+CmfPqsZ74HqIqkOcwMnBD/1nJs6sqb8Mn96ljK2dlQeWg==
+-----END PUBLIC KEY-----
+
+SHA256 Digest:
+702a3d56f05b2f72531d650825e20041e2e9d9318c34b6853ab9066e5c72e80c
+
+* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
+COSE:
+  Prot Hdr:   1 : -7 (ECDSA w/ SHA-256)
+  Unprot Hdr: 4 : -2 (identity_key)
+  ---------------
+  Attestation:
+    Payload ID: CSR_msg_v1
+    Dev UUID:  50363154-3931-44f0-8022-121b6401627d
+    sec_tag:    17
+    SHA256:     702a3d56f05b2f72531d650825e20041e2e9d9318c34b6853ab9066e5c72e80c
+    Nonce:      1b8722ee1deb581566e2cb1359b27cd2
+  ---------------
+  Sig:
+      d489397bc3016dd2112c0a2110b318fe842b69064f196bc5177dd032729c767da08e3c922b91f9a2492f3e63aff6b5302800c3750625a24ce8a6635c1913751d
+
+COSE digest matches payload
+* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
+```
+
+### KEYGEN - Public Key: `AT%KEYGEN=16,2,1`
+```
+python3 modem_credentials_parser.py -k MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEZKgDx0O0FKa7i1yFoxYngNdV5Csyi4rEPHcFTfeBVtkkJX-G0QZs-yesfzIaPs91b4x5xYN_g28k63gkeVMJwA.0oRDoQEmoQRBIVhL2dn3hQhQUDYxVDkxRPCAIhIbZAFifUEQWCDlovwqMVoJ1W-x93Tqypy2v_1ALv3-GCF1R9gYIy2WVlBQXvxKqA9JTveFh3nVwce-WEAMltwSSkVh8jSBPhP79ndSG0HJTOaTF9SExIq-FstjdLUW2inxdvVfqzLa05rgXqxshN5vfQIs22QT-swCt30h
+
+Parsing AT%KEYGEN output:
+
+Device public key:
+-----BEGIN PUBLIC KEY-----
+MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEZKgDx0O0FKa7i1yFoxYngNdV5Csy
+i4rEPHcFTfeBVtkkJX+G0QZs+yesfzIaPs91b4x5xYN/g28k63gkeVMJwA==
+-----END PUBLIC KEY-----
+
+SHA256 Digest:
+e5a2fc2a315a09d56fb1f774eaca9cb6bffd402efdfe18217547d818232d9656
+
+* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
+COSE:
+  Prot Hdr:   1 : -7 (ECDSA w/ SHA-256)
+  Unprot Hdr: 4 : -2 (identity_key)
+  ---------------
+  Attestation:
+    Payload ID: pubkey_msg_v2
+    Dev UUID:   50363154-3931-44f0-8022-121b6401627d
+    sec_tag:    16
+    SHA256:     e5a2fc2a315a09d56fb1f774eaca9cb6bffd402efdfe18217547d818232d9656
+    Nonce:      505efc4aa80f494ef7858779d5c1c7be
+  ---------------
+  Sig:
+      0c96dc124a4561f234813e13fbf677521b41c94ce69317d484c48abe16cb6374b516da29f176f55fab32dad39ae05eac6c84de6f7d022cdb6413facc02b77d21
+
+COSE digest matches payload
+* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
+```
+
+### AT%ATTESTTOKEN
+```
+python3 modem_credentials_parser.py -a 2dn3hQFQUDYxVDkxRPCAIhIbZAFifQNQGv86y_GmR2SiY0wmRsHGVFDT791_BPH8YOWFiyCHND1q.0oRDoQEmoQRBIfZYQGuXwJliinHc6xDPruiyjsaXyXZbZVpUuOhHG9YS8L05VuglCcJhMN4EUhWVGpaHgNnHHno6ahi-d5tOeZmAcNY
+
+Parsing AT%ATTESTTOKEN output:
+
+---------------
+Msg Type:    Device identity message v1
+Dev UUID:    50363154-3931-44f0-8022-121b6401627d
+Dev Type:    NRF9160 SIAA
+FW UUID:     1aff3acb-f1a6-4764-a263-4c2646c1c654
+---------------
+* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
+COSE:
+  Prot Hdr:   1 : -7 (ECDSA w/ SHA-256)
+  Unprot Hdr: 4 : -2 (identity_key)
+  ---------------
+  Attestation:
+    Not present
+  ---------------
+  Sig:
+      6b97c099628a71dceb10cfaee8b28ec697c9765b655a54b8e8471bd612f0bd3956e82509c26130de045215951a968780d9c71e7a3a6a18be779b4e79998070d6
+* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
+```
+
+### KEYGEN - Certificate Signing Request (CSR) + File Save: `AT%KEYGEN=17,2,0`
+```
+python3 modem_credentials_parser.py -k MIIBCjCBrwIBADAvMS0wKwYDVQQDDCQ1MDM2MzE1NC0zOTMxLTQ0ZjAtODAyMi0xMjFiNjQwMTYyN2QwWTATBgcqhkjOPQIBBggqhkjOPQMBBwNCAAQqD6pNfa29o_EXnw62bnQWr8-JqsNh_HZxS3k3bMD4KZ8-qxnvgeoiqQ5zAycEP_Wcmzqypvwyf3qWMrZ2VB5aoB4wHAYJKoZIhvcNAQkOMQ8wDTALBgNVHQ8EBAMCA-gwDAYIKoZIzj0EAwIFAANIADBFAiEAv7OLZ_dXbszfhhjcLMUT72wTmw-z6GlgWxVhyWgR27ACIAvY_lPu3yfYZY5AL6uYTkUFp4GQkbSOUC_lsHyCxOuG.0oRDoQEmoQRBIVhL2dn3hQlQUDYxVDkxRPCAIhIbZAFifUERWCBwKj1W8FsvclMdZQgl4gBB4unZMYw0toU6uQZuXHLoDFAbhyLuHetYFWbiyxNZsnzSWEDUiTl7wwFt0hEsCiEQsxj-hCtpBk8Za8UXfdAycpx2faCOPJIrkfmiSS8-Y6_2tTAoAMN1BiWiTOimY1wZE3Ud -p /my_devices/pem_files -f hw_rev2-
+
+Parsing AT%KEYGEN output:
+
+-----BEGIN CERTIFICATE REQUEST-----
+MIIBCjCBrwIBADAvMS0wKwYDVQQDDCQ1MDM2MzE1NC0zOTMxLTQ0ZjAtODAyMi0x
+MjFiNjQwMTYyN2QwWTATBgcqhkjOPQIBBggqhkjOPQMBBwNCAAQqD6pNfa29o/EX
+nw62bnQWr8+JqsNh/HZxS3k3bMD4KZ8+qxnvgeoiqQ5zAycEP/Wcmzqypvwyf3qW
+MrZ2VB5aoB4wHAYJKoZIhvcNAQkOMQ8wDTALBgNVHQ8EBAMCA+gwDAYIKoZIzj0E
+AwIFAANIADBFAiEAv7OLZ/dXbszfhhjcLMUT72wTmw+z6GlgWxVhyWgR27ACIAvY
+/lPu3yfYZY5AL6uYTkUFp4GQkbSOUC/lsHyCxOuG
+-----END CERTIFICATE REQUEST-----
+
+Device public key:
+-----BEGIN PUBLIC KEY-----
+MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEKg+qTX2tvaPxF58Otm50Fq/PiarD
+Yfx2cUt5N2zA+CmfPqsZ74HqIqkOcwMnBD/1nJs6sqb8Mn96ljK2dlQeWg==
+-----END PUBLIC KEY-----
+
+SHA256 Digest:
+702a3d56f05b2f72531d650825e20041e2e9d9318c34b6853ab9066e5c72e80c
+
+* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
+COSE:
+  Prot Hdr:   1 : -7 (ECDSA w/ SHA-256)
+  Unprot Hdr: 4 : -2 (identity_key)
+  ---------------
+  Attestation:
+    Payload ID: CSR_msg_v1
+    Dev UUID:   50363154-3931-44f0-8022-121b6401627d
+    sec_tag:    17
+    SHA256:     702a3d56f05b2f72531d650825e20041e2e9d9318c34b6853ab9066e5c72e80c
+    Nonce:      1b8722ee1deb581566e2cb1359b27cd2
+  ---------------
+  Sig:
+      d489397bc3016dd2112c0a2110b318fe842b69064f196bc5177dd032729c767da08e3c922b91f9a2492f3e63aff6b5302800c3750625a24ce8a6635c1913751d
+
+COSE digest matches payload
+* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
+Argument -s has been selected since path/fileprefix was specified
+File created: /my_devices/pem_files/hw_rev2-50363154-3931-44f0-8022-121b6401627d_17_csr.pem
+File created: /my_devices/pem_files/hw_rev2-50363154-3931-44f0-8022-121b6401627d_17_pub.pem
+```
+
+## Create Device Credentials
+The script above, `device_credentials_installer.py` makes use of this script, `create_device_credentials.py`, so if you use the former, you do not need to also follow the directions below.  If `device_credentials_installer.py` does not meet your needs, you can use `create_device_credentialsr.py` directly to take advantage of additional options.
+
+This script creates device credentials for use with nRF Cloud.  It requires a CA certificate and the associated private key as an input.  It optionally accepts a CSR (from `AT%KEYGEN`/modem_credentials_parser.py).
+
+The output file name format is as follows:
+`<your_prefix><CN>_crt.pem`
+`<your_prefix><CN>_pub.pem`
+if no CSR provided:
+`<your_prefix><CN>_prv.pem`
+If no CN (common name) is provided/available, the serial number hex value will be used.
+```
+usage: create_device_credentials.py [-h] -ca CA -ca_key CA_KEY -c C [-st ST] [-l L] [-o O] [-ou OU] [-cn CN] [-e EMAIL] [-dv DV]
+            [-p PATH] [-f FILEPREFIX] [-csr CSR]
+
+Create Device Credentials
+
+optional arguments:
+  -h, --help            show this help message and exit
+  -ca CA                Filepath to your CA cert PEM
+  -ca_key CA_KEY        Filepath to your CA's private key PEM
+  -c C                  2 character country code; required if CSR is not provided
+  -st ST                State or Province; ignored if CSR is provided
+  -l L                  Locality; ignored if CSR is provided
+  -o O                  Organization; ignored if CSR is provided
+  -ou OU                Organizational Unit; ignored if CSR is provided
+  -cn CN                Common Name; use nRF Cloud device ID/MQTT client ID; ignored if CSR is provided
+  -e EMAIL, --email EMAIL
+                        E-mail address; ignored if CSR is provided
+  -dv DV                Number of days cert is valid
+  -p PATH, --path PATH  Path to save PEM files.
+  -f FILEPREFIX, --fileprefix FILEPREFIX
+                        Prefix for output files
+  -csr CSR              Filepath to CSR PEM from device
+```
+
+## Examples
+
+### No CSR provided:
+```
+python3 create_device_credentials.py -ca /my_ca/my_company-0x3bc7f3b014a8ad492999c594f08bbc2fcffc5fd1_ca.pem -ca_key /my_ca/my_company-0x3bc7f3b014a8ad492999c594f08bbc2fcffc5fd1_prv.pem -c US -st WA -l Seattle -o "My Company" -ou "Devs" -cn my-unique-device-id -e email@example.com -dv 2000 -p /dev_credentials -f hw_rev2-
+Creating device credentials...
+File created: /dev_credentials/hw_rev2-my-unique-device-id_crt.pem
+File created: /dev_credentials/hw_rev2-my-unique-device-id_pub.pem
+File created: /dev_credentials/hw_rev2-my-unique-device-id_prv.pem
+```
+
+### CSR provided:
+```
+python3 create_device_credentials.py -ca /my_ca/my_company-0x3bc7f3b014a8ad492999c594f08bbc2fcffc5fd1_ca.pem -ca_key /my_ca/my_company-0x3bc7f3b014a8ad492999c594f08bbc2fcffc5fd1_prv.pem -csr /my_devices/pem_files/hw_rev2-50363154-3931-44f0-8022-121b6401627d_17_csr.pem -dv 2000 -p /dev_credentials -f hw_rev2-
+Creating device credentials...
+File created: /dev_credentials/hw_rev2-50363154-3931-44f0-8022-121b6401627d_crt.pem
+File created: /dev_credentials/hw_rev2-50363154-3931-44f0-8022-121b6401627d_pub.pem
 ```


### PR DESCRIPTION
The device_credentials_installer.py uses the modem_credentials_parser.py and create_device_credentials.py scripts, so the direct use of those latter scripts is optional.  Clarify this.

This change was made based on comments from developers in Norway.