### PR TITLE
add --verify option

### DIFF
--- a/python/modem-firmware-1.3+/requirements.txt
+++ b/python/modem-firmware-1.3+/requirements.txt
@@ -1,8 +1,11 @@
+auto_mix_prep>=0.2.0
 cbor2>=5.4.2.post1
 colorama>=0.4.4
 cryptography>=36.0.1
-pynrfjprog==10.17.3
 loguru>=0.6.0
-pyOpenSSL>=22.0.0
+pylink>=0.3.3
+pylink_square>=0.11.1
+pynrfjprog>=10.23.0
+pyOpenSSL>=23.2.0
 pyserial>=3.5
 requests>=2.27.1


### PR DESCRIPTION
Add `--verify` option which verifies that the device has credentials in each slot of the sec tag and that the SHA matches what was written.
A feature request from @junqingzou 