### PR TITLE
Fix CSR response handling

### DIFF
--- a/python/modem-firmware-1.3+/claim_and_provision_device.py
+++ b/python/modem-firmware-1.3+/claim_and_provision_device.py
@@ -533,6 +533,10 @@ def main():
 
     # get the CSR from the response
     csr_txt = cmd_response.get('certificateSigningRequest').get('csr')
+    if csr_txt == None:
+        csr_txt = cmd_response.get('certificateSigningRequest').get('message')
+        if csr_txt == None:
+            error_exit('CSR response not found')
     if csr_txt:
         print(hivis_style('CSR:\n' + csr_txt + '\n'))
 


### PR DESCRIPTION
The response to a certificate signing request has changed from `csr` to `message`. Handle either for now, until all stages are the same.