### PR TITLE
device_credentials_installer: Fix TLSCredShellInterface constructor

### DIFF
--- a/python/modem-firmware-1.3+/device_credentials_installer.py
+++ b/python/modem-firmware-1.3+/device_credentials_installer.py
@@ -652,7 +652,7 @@ def main():
             cred_if.set_shell_mode(True)
 
     if args.cmd_type == CMD_TYPE_TLS_SHELL:
-        cred_if = TLSCredShellInterface(write_line, wait_for_prompt, verbose, True)
+        cred_if = TLSCredShellInterface(write_line, wait_for_prompt, verbose)
 
     # prepare modem so we can interact with security keys
     if (cmd_type_has_at):


### PR DESCRIPTION
Spurious fourth argument was included on the constructor for TLSCredShellInterface. Remove it.

fixes #44