### PR TITLE
Add nRF7002 support: Using TLS credentials shell

### DIFF
--- a/src/nrfcloud_utils/device_credentials_installer.py
+++ b/src/nrfcloud_utils/device_credentials_installer.py
@@ -149,6 +149,9 @@ def parse_args(in_args):
     parser.add_argument("--local-cert-file", type=str,
                         help="Filepath to a local certificate (PEM) to use for the device",
                         default="")
+    parser.add_argument("--cert-type", type=int,
+                        help="Certificate type to use for the device",
+                        default=1)
     args = parser.parse_args(in_args)
     return args
 
@@ -641,8 +644,8 @@ def main(in_args):
 
         if args.delete:
             print(local_style('Deleting sectag {}...'.format(args.sectag)))
-            cred_if.delete_credential(args.sectag, 1)
-        cred_if.write_credential(args.sectag, 1, dev_bytes)
+            cred_if.delete_credential(args.sectag, args.cert_type)
+        cred_if.write_credential(args.sectag, args.cert_type, dev_bytes)
         if rtt:
             rtt.close()
         cleanup()


### PR DESCRIPTION
nRF7002 enterprise mode needs installing about 3-6certs (see https://docs.zephyrproject.org/latest/connectivity/networking/api/wifi.html#wi-fi-enterprise-test-x-509-certificate-header-generation) so instead of pre-defined certs, add a provision to take a arbitrary cert (CA, server or client and private keys too) and install using TLS credentials (no AT commands supported in nRF70 Series).

To keep the code clean, add a separate option and exit early.