### PR TITLE
Update poetry in ci from 1.4.2->2.2.1

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -11,6 +11,7 @@ on:
 env:
   REGISTRY_NAME: ${{ vars.REGISTRY_NAME }}
   REGISTRY_URI: ${{ vars.REGISTRY_URI }}
+  POETRY_VERSION: 2.2.1
 
 jobs:
   build:
@@ -30,7 +31,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
       - name: Install poetry
         run: |
-          curl -sSL https://install.python-poetry.org | POETRY_VERSION=1.4.2 python3 -
+          curl -sSL https://install.python-poetry.org | POETRY_VERSION=$POETRY_VERSION python3 -
       - name: Install dependencies
         run: |
           poetry install
@@ -55,7 +56,7 @@ jobs:
           python-version: 3.11
       - name: Install poetry
         run: |
-          curl -sSL https://install.python-poetry.org | POETRY_VERSION=1.4.2 python3 -
+          curl -sSL https://install.python-poetry.org | POETRY_VERSION=$POETRY_VERSION python3 -
       - name: Update version in pyproject.toml
         run: |
           echo $GITHUB_REF_NAME | sed 's/^v//' | xargs poetry version


### PR DESCRIPTION
Primarily to get new classifiers for showing supported python version on
PyPi (and in the badge in the readme here).

It's easy to verify this locally by using `uvx` to run versions of poetry to
build the .whl, and examine the wheel metadata:

```bash
❯ uvx --from=poetry==1.4.0 poetry -q build && unzip -q dist/nrfcloud_utils-*-py3-none-any.whl && rg 'Classifier: Programming Language :: Python' nrfcloud_utils-*.dist-info/METADATA && rm -rf nrfcloud_utils*
10:Classifier: Programming Language :: Python :: 3
11:Classifier: Programming Language :: Python :: 3.10
12:Classifier: Programming Language :: Python :: 3.11

❯ uvx --from=poetry==2.2.1 poetry -q build && unzip -q dist/nrfcloud_utils-*-py3-none-any.whl && rg 'Classifier: Programming Language :: Python' nrfcloud_utils-*.dist-info/METADATA && rm -rf nrfcloud_utils*
10:Classifier: Programming Language :: Python :: 3
11:Classifier: Programming Language :: Python :: 3.10
12:Classifier: Programming Language :: Python :: 3.11
13:Classifier: Programming Language :: Python :: 3.12
14:Classifier: Programming Language :: Python :: 3.13
15:Classifier: Programming Language :: Python :: 3.14
```
