### PR TITLE
Improve error logging

### DIFF
--- a/src/nrfcloud_utils/claim_and_provision_device.py
+++ b/src/nrfcloud_utils/claim_and_provision_device.py
@@ -163,7 +163,11 @@ def main(in_args):
     cred_if = None
     cred_if = ATCommandInterface(serial_interface)
     if args.cmd_type == CMD_TYPE_AUTO:
-        cred_if.detect_shell_mode()
+        try:
+            cred_if.detect_shell_mode()
+        except TimeoutError as e:
+            logger.error(f"{e}")
+            sys.exit(12)
     elif args.cmd_type == CMD_TYPE_AT_SHELL:
         cred_if.set_shell_mode(True)
     elif args.rtt:

--- a/src/nrfcloud_utils/device_credentials_installer.py
+++ b/src/nrfcloud_utils/device_credentials_installer.py
@@ -235,7 +235,11 @@ def main(in_args):
     if cmd_type_has_at:
         cred_if = ATCommandInterface(serial_interface)
         if args.cmd_type == CMD_TYPE_AUTO:
-            cred_if.detect_shell_mode()
+            try:
+                cred_if.detect_shell_mode()
+            except TimeoutError as e:
+                logger.error(f"{e}")
+                sys.exit(12)
             logger.debug(f'Detected shell mode: {cred_if.shell}')
         elif args.cmd_type == CMD_TYPE_AT_SHELL:
             cred_if.set_shell_mode(True)

--- a/src/nrfcloud_utils/gather_attestation_tokens.py
+++ b/src/nrfcloud_utils/gather_attestation_tokens.py
@@ -168,7 +168,11 @@ def main(in_args):
     cred_if = None
     cred_if = ATCommandInterface(serial_interface)
     if args.cmd_type == CMD_TYPE_AUTO:
-        cred_if.detect_shell_mode()
+        try:
+            cred_if.detect_shell_mode()
+        except TimeoutError as e:
+            logger.error(f"{e}")
+            sys.exit(12)
     elif args.cmd_type == CMD_TYPE_AT_SHELL:
         cred_if.set_shell_mode(True)
     elif args.rtt:


### PR DESCRIPTION
The exception displayed in case there is a timeout when trying to identify what type of communication to have with the device is not user-friendly. This PR look to improve it.