### PR TITLE
device_credentials_installer: add nrf_cloud_cred_shell cmd type

### DIFF
--- a/src/nrfcloud_utils/cli_helpers.py
+++ b/src/nrfcloud_utils/cli_helpers.py
@@ -217,6 +217,7 @@ CMD_TERM_DICT = {'NULL': '\0',
 CMD_TYPE_AT = "at"
 CMD_TYPE_AT_SHELL = "at_shell"
 CMD_TYPE_TLS_SHELL = "tls_cred_shell"
+CMD_TYPE_NRF_CLOUD_CRED_SHELL = "nrf_cloud_cred_shell"
 CMD_TYPE_AUTO = "auto"
 
 def parser_add_comms_args(parser):
@@ -244,8 +245,8 @@ def parser_add_comms_args(parser):
     parser.add_argument("--rtt",
                         help="Use RTT instead of serial. Requires device run Modem Shell sample application configured with RTT overlay",
                         action='store_true', default=False)
-    parser.add_argument("--cmd-type", default=CMD_TYPE_AUTO, choices=[CMD_TYPE_AUTO, CMD_TYPE_AT, CMD_TYPE_AT_SHELL, CMD_TYPE_TLS_SHELL], type=str.lower,
-                    help=f"Specify the device command line type. '{CMD_TYPE_AT}' will use AT commands, '{CMD_TYPE_AT_SHELL}' will prefix AT commands with 'at ', and '{CMD_TYPE_TLS_SHELL}' will use TLS Credentials Shell commands.")
+    parser.add_argument("--cmd-type", default=CMD_TYPE_AUTO, choices=[CMD_TYPE_AUTO, CMD_TYPE_AT, CMD_TYPE_AT_SHELL, CMD_TYPE_TLS_SHELL, CMD_TYPE_NRF_CLOUD_CRED_SHELL], type=str.lower,
+                    help=f"Specify the device command line type. '{CMD_TYPE_AT}' will use AT commands, '{CMD_TYPE_AT_SHELL}' will prefix AT commands with 'at ', '{CMD_TYPE_TLS_SHELL}' will use TLS Credentials Shell commands, and '{CMD_TYPE_NRF_CLOUD_CRED_SHELL}' will use the nrf_cloud_cred shell commands to generate the device key and CSR on-device.")
     parser.add_argument("--term", type=str,
                         help="AT command termination",choices=list(CMD_TERM_DICT.keys()),
                         default='CRLF')

--- a/src/nrfcloud_utils/device_credentials_installer.py
+++ b/src/nrfcloud_utils/device_credentials_installer.py
@@ -9,12 +9,13 @@ import re
 import os
 import sys
 import uuid
+import base64
 import semver
 import logging
 from nrfcloud_utils import create_device_credentials, ca_certs, modem_credentials_parser
 from nrfcloud_utils.cli_helpers import write_file, save_devinfo_csv, save_onboarding_csv, full_encoding, setup_logging
-from nrfcloud_utils.cli_helpers import CMD_TERM_DICT, CMD_TYPE_AUTO, CMD_TYPE_AT, CMD_TYPE_AT_SHELL, CMD_TYPE_TLS_SHELL, parser_add_comms_args
-from nrfcredstore.command_interface import ATCommandInterface, TLSCredShellInterface
+from nrfcloud_utils.cli_helpers import CMD_TERM_DICT, CMD_TYPE_AUTO, CMD_TYPE_AT, CMD_TYPE_AT_SHELL, CMD_TYPE_TLS_SHELL, CMD_TYPE_NRF_CLOUD_CRED_SHELL, parser_add_comms_args
+from nrfcredstore.command_interface import ATCommandInterface, TLSCredShellInterface, NrfCloudCredShellInterface
 from nrfcredstore.comms import Comms
 
 from cryptography import x509
@@ -172,8 +173,13 @@ def get_csr(cred_if, custom_dev_id = "", sectag = 0, local = False):
             logger.error('Failed to obtain CSR from device')
             sys.exit(9)
 
-        csr_bytes, _, _, _ = modem_credentials_parser.parse_keygen_output(csr_blob)
-        csr = x509.load_pem_x509_csr(csr_bytes)
+        if isinstance(cred_if, NrfCloudCredShellInterface):
+            # The nrf_cloud_cred shell returns a plain Base64-encoded DER CSR,
+            # not the modem's "body.cose" format.
+            csr = x509.load_der_x509_csr(base64.b64decode(csr_blob))
+        else:
+            csr_bytes, _, _, _ = modem_credentials_parser.parse_keygen_output(csr_blob)
+            csr = x509.load_pem_x509_csr(csr_bytes)
 
     return csr, local_priv_key
 
@@ -217,7 +223,7 @@ def main(in_args):
         logger.error(f"cmd_type '{CMD_TYPE_TLS_SHELL}' currently requires --local_cert or --local_cert_file")
         sys.exit(1)
 
-    if args.cmd_type == CMD_TYPE_TLS_SHELL and id_len == 0:
+    if args.cmd_type in (CMD_TYPE_TLS_SHELL, CMD_TYPE_NRF_CLOUD_CRED_SHELL) and id_len == 0:
         args.id_str = str(uuid.uuid4())
 
     cmd_type_has_at = args.cmd_type in (CMD_TYPE_AT, CMD_TYPE_AT_SHELL, CMD_TYPE_AUTO)
@@ -248,6 +254,10 @@ def main(in_args):
 
     if args.cmd_type == CMD_TYPE_TLS_SHELL:
         cred_if = TLSCredShellInterface(serial_interface)
+        has_shell = True
+
+    if args.cmd_type == CMD_TYPE_NRF_CLOUD_CRED_SHELL:
+        cred_if = NrfCloudCredShellInterface(serial_interface)
         has_shell = True
 
     # prepare modem so we can interact with security keys

--- a/src/nrfcloud_utils/device_credentials_installer.py
+++ b/src/nrfcloud_utils/device_credentials_installer.py
@@ -223,6 +223,13 @@ def main(in_args):
         logger.error(f"cmd_type '{CMD_TYPE_TLS_SHELL}' currently requires --local_cert or --local_cert_file")
         sys.exit(1)
 
+    if args.cmd_type == CMD_TYPE_NRF_CLOUD_CRED_SHELL and (args.local_cert or args.local_cert_file):
+        # The key and CSR are generated on-device; generating a key on the host
+        # would defeat the purpose and is almost certainly a mistake.
+        logger.error(f"cmd_type '{CMD_TYPE_NRF_CLOUD_CRED_SHELL}' generates the key on-device; "
+                     "do not use --local-cert or --local-cert-file")
+        sys.exit(1)
+
     if args.cmd_type in (CMD_TYPE_TLS_SHELL, CMD_TYPE_NRF_CLOUD_CRED_SHELL) and id_len == 0:
         args.id_str = str(uuid.uuid4())
 
@@ -453,6 +460,27 @@ def main(in_args):
     if args.devinfo:
         save_devinfo_csv(args.devinfo, args.devinfo_append, args.replace, dev_id, mfw_ver, imei)
 
+def verify_on_device_key(cred_if, sec_tag, client_cert):
+    # The on-device private key is non-exportable, so it cannot be verified by
+    # hash. Instead, confirm that the device public key matches the public key
+    # in the installed device certificate.
+    logger.info('Verifying Private Key')
+    dev_pub = cred_if.get_pubkey(sec_tag)
+    if not dev_pub:
+        logger.error('...Failed to read device public key')
+        return False
+
+    cert = x509.load_pem_x509_certificate(client_cert.encode())
+    cert_pub = cert.public_key().public_bytes(
+        serialization.Encoding.X962, serialization.PublicFormat.UncompressedPoint)
+
+    if dev_pub != cert_pub:
+        logger.error('...Device public key does not match the device certificate')
+        return False
+
+    logger.info('...Private Key matches device certificate')
+    return True
+
 def verify_credentials(cred_if, sec_tag, ca_cert, client_cert, client_prv=None, check_sha=False):
     # verify the CA cert
     if not verify_credential(cred_if, sec_tag, 0, ca_cert, verify_hash = check_sha):
@@ -461,6 +489,11 @@ def verify_credentials(cred_if, sec_tag, ca_cert, client_cert, client_prv=None, 
     # verify client cert
     if not verify_credential(cred_if, sec_tag, 1, client_cert, verify_hash = check_sha):
         return False
+
+    # The on-device key is opaque (held in PSA); verify it by matching the
+    # device public key to the certificate instead of by hash.
+    if isinstance(cred_if, NrfCloudCredShellInterface):
+        return verify_on_device_key(cred_if, sec_tag, client_cert)
 
     if not verify_credential(cred_if, sec_tag, 2, client_prv, get_hash = check_sha,
                              verify_hash = (client_prv is not None) and check_sha):


### PR DESCRIPTION
Add a new --cmd-type 'nrf_cloud_cred_shell' that uses the NrfCloudCredShellInterface to generate the device private key and CSR on-device via the 'nrf_cloud_cred' shell commands.

The CSR returned by this interface is plain Base64-encoded DER (not the modem's body.cose format), so get_csr() decodes it with load_der_x509_csr(). As with tls_cred_shell, a random device id is used when none is provided. The private key stays in PSA on the device; only CA and device certificates are written via the TLS Credentials Shell.